### PR TITLE
Add Task-Specific Mode and Make it Optional

### DIFF
--- a/alsek/__init__.py
+++ b/alsek/__init__.py
@@ -10,4 +10,4 @@ from alsek.core.message import Message
 from alsek.core.status import StatusTracker
 from alsek.core.task import task
 
-__version__: str = "0.4.2"
+__version__: str = "0.5.0"

--- a/alsek/cli/cli.py
+++ b/alsek/cli/cli.py
@@ -19,12 +19,18 @@ from alsek.utils.scanning import collect_tasks, parse_logging_level
 @click.version_option(__version__)
 @click.argument("module", type=str)
 @click.option(
-    "-q",
+    "-qu",
     "--queues",
     type=str,
     default=None,
     help="Comma separated list of queues to consume from. "
     "If null, all queues will be consumed.",
+)
+@click.option(
+    "-ts",
+    "--task_specific",
+    is_flag=True,
+    help="Narrowly monitor the tasks (true) or queues more broadly (false; default)",
 )
 @click.option(
     "--max_threads",
@@ -83,6 +89,7 @@ from alsek.utils.scanning import collect_tasks, parse_logging_level
 def main(
     module: str,
     queues: Optional[str],  # noqa
+    task_specific: bool,  # noqa
     max_threads: int,  # noqa
     max_processes: Optional[int],  # noqa
     management_interval: int,  # noqa
@@ -113,6 +120,7 @@ def main(
     WorkerPool(
         tasks=collect_tasks(module),
         queues=[i.strip() for i in queues.split(",")] if queues else None,
+        task_specific=task_specific,
         max_threads=max_threads,
         max_processes=max_processes,
         management_interval=management_interval,

--- a/alsek/cli/cli.py
+++ b/alsek/cli/cli.py
@@ -27,8 +27,8 @@ from alsek.utils.scanning import collect_tasks, parse_logging_level
     "If null, all queues will be consumed.",
 )
 @click.option(
-    "-ts",
-    "--task_specific",
+    "-tsm",
+    "--task_specific_mode",
     is_flag=True,
     help="Narrowly monitor the tasks (true) or queues more broadly (false; default)",
 )
@@ -89,7 +89,7 @@ from alsek.utils.scanning import collect_tasks, parse_logging_level
 def main(
     module: str,
     queues: Optional[str],  # noqa
-    task_specific: bool,  # noqa
+    task_specific_mode: bool,  # noqa
     max_threads: int,  # noqa
     max_processes: Optional[int],  # noqa
     management_interval: int,  # noqa
@@ -120,7 +120,7 @@ def main(
     WorkerPool(
         tasks=collect_tasks(module),
         queues=[i.strip() for i in queues.split(",")] if queues else None,
-        task_specific=task_specific,
+        task_specific_mode=task_specific_mode,
         max_threads=max_threads,
         max_processes=max_processes,
         management_interval=management_interval,

--- a/alsek/core/task.py
+++ b/alsek/core/task.py
@@ -305,22 +305,12 @@ class Task:
             * ``submit`` is overridden to ``False`` if deferred mode is active
             * ``uuid`` is refreshed after the first event when using a trigger.
             * If manually overriding ``queue`` such that it differs from the default
-              for this task, Worker Pools built by automatically extracting the queue
-              on which a task runs using the default queue for this task may fail
-              to acknowledge its existence. If this problem occurs it can be resolved
-              by manually enumerating all the possible queues on which this task
-              will be entered when defining it.
+              for this task, Worker Pools built using ``task_specific_mode=True`` will
+              fail acknowledge its existence.
 
         """
         if result_ttl and not self.result_store:
             raise ValidationError(f"`result_ttl` invalid. No result store set.")
-        elif queue and queue != self.queue:
-            log.warning(
-                "Assigning task to non-default queue '%s'. "
-                "Worker pools built without manual specification of "
-                "supported queues may not acknowledge this message.",
-                queue,
-            )
 
         message = Message(
             task_name=self.name,

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -216,9 +216,9 @@ class WorkerPool(Consumer):
         log.info(
             "Starting worker pool with %s max thread%s and %s max process%s...",
             self.max_threads,
-            "(s)" if self.max_threads > 1 else "",
+            "" if self.max_threads == 1 else "(s)",
             self.max_processes,
-            "(es)" if self.max_processes > 1 else "",
+            "" if self.max_processes == 1 else "(es)",
         )
         self._pool_manager.start()
         log.info(

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -120,7 +120,7 @@ class WorkerPool(Consumer):
             **kwargs,
         )
         self.tasks = tasks
-        self.queues = queues
+        self.queues = queues or sorted(self.subset)
         self.task_specific_mode = task_specific_mode
         self.max_threads = max_threads
         self.max_processes = max_processes or smart_cpu_count()

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -47,15 +47,22 @@ def _extract_broker(tasks: Collection[Task]) -> Broker:
 def _derive_consumer_subset(
     tasks: Collection[Task],
     queues: Optional[list[str]],
+    task_specific: bool,
 ) -> dict[str, list[str]]:
     if queues and has_duplicates(queues):
         raise ValueError(f"Duplicates in provided queues: {queues}")
+    elif queues and not task_specific:
+        return queues
 
     subset: DefaultDict[str, list[str]] = defaultdict(list)
     for t in sorted(tasks, key=lambda i: i.priority):
         if queues is None or t.queue in queues:
             subset[t.queue].append(t.name)
-    return dict_sort(subset, key=queues.index if queues else None)
+
+    if task_specific:
+        return dict_sort(subset, key=queues.index if queues else None)
+    else:
+        return sorted(subset.keys())
 
 
 class WorkerPool(Consumer):
@@ -71,6 +78,8 @@ class WorkerPool(Consumer):
             to ``queues``.
         queues (list[str], optional): the names of one or more queues
             consume messages from. If ``None``, all queues will be consumed.
+        task_specific (bool, optional): when defining queues to monitor, include
+            tasks names. Otherwise, consider queues broadly.
         max_threads (int): the maximum of tasks with ``mechanism="thread"``
             supported at any 'one' time.
         max_processes (int, optional): the maximum of tasks with ``mechanism="process"``
@@ -94,6 +103,7 @@ class WorkerPool(Consumer):
         self,
         tasks: Collection[Task],
         queues: Optional[list[str]] = None,
+        task_specific: bool = False,
         max_threads: int = 8,
         max_processes: Optional[int] = None,
         management_interval: int = 100,
@@ -102,7 +112,11 @@ class WorkerPool(Consumer):
     ) -> None:
         super().__init__(
             broker=_extract_broker(tasks),
-            subset=_derive_consumer_subset(tasks, queues=queues),
+            subset=_derive_consumer_subset(
+                tasks=tasks,
+                queues=queues,
+                task_specific=task_specific,
+            ),
             **kwargs,
         )
         self.tasks = tasks

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -214,13 +214,15 @@ class WorkerPool(Consumer):
 
         """
         log.info(
-            "Starting worker pool with %s max thread(s) and %s max process(es)...",
+            "Starting worker pool with %s max thread%s and %s max process%s...",
             self.max_threads,
+            "(s)" if self.max_threads > 1 else "",
             self.max_processes,
+            "(es)" if self.max_processes > 1 else "",
         )
         self._pool_manager.start()
         log.info(
-            "Monitoring %s %s",
+            "Monitoring %s %s.",
             len(self.tasks) if self.task_specific_mode else len(self.queues),
             "tasks" if self.task_specific_mode else "queues"
         )

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -121,6 +121,7 @@ class WorkerPool(Consumer):
         )
         self.tasks = tasks
         self.queues = queues
+        self.task_specific = task_specific
         self.max_threads = max_threads
         self.max_processes = max_processes or smart_cpu_count()
         self.management_interval = management_interval
@@ -218,7 +219,11 @@ class WorkerPool(Consumer):
             self.max_processes,
         )
         self._pool_manager.start()
-        log.info("Monitoring to %s tasks", len(self.tasks))
+        log.info(
+            "Monitoring %s %s",
+            len(self.tasks) if self.task_specific else len(self.queues),
+            "tasks" if self.task_specific else "queues"
+        )
         log.info("Worker pool online.")
 
         try:

--- a/docs/guided_tour.md
+++ b/docs/guided_tour.md
@@ -879,15 +879,15 @@ alsek my_project
 Alsek's CLI includes several dials to achieve fine-grain control over the worker pool.
 We won't cover all of them here, but there are at least three worth highlighting.
 
-The first is the `-q`/`--queues` option. This allows one to limit the queues
+The first is the `-qu`/`--queues` option. This allows one to limit the queues
 which will be consumed by the worker pool. It can be set using a comma-separated list.
 
 ```shell
-alsek my_project -q queue_a
+alsek my_project -qu queue_a
 ```
 
 ```shell
-alsek my_project -q queue_a,queue_b,queue_z
+alsek my_project -qu queue_a,queue_b,queue_z
 ```
 
 The `--max_threads` and `--max_processes` options are also noteworthy.
@@ -905,7 +905,7 @@ alsek my_project --max_processes 2
 
 !!! note
     The worker pool's `Consumer` will respect the order in which queues
-    are listed for the `-q`/`--queues` option. If, this option is not specified, 
+    are listed for the `-qu`/`--queues` option. If, this option is not specified, 
     queues will be consumed in alphabetical order.
 
 !!! note

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
 name = alsek
-version = 0.4.2
+version = 0.5.0
 author = Tariq Hassan

--- a/tests/core/worker/test_helpers.py
+++ b/tests/core/worker/test_helpers.py
@@ -40,7 +40,7 @@ def test_extract_broker_multi_broker(rolling_backend: Backend) -> None:
 
 
 @pytest.mark.parametrize(
-    "task_names,queues,task_specific,expected",
+    "task_names,queues,task_specific_mode,expected",
     [
         # Tasks & no queues specified
         (
@@ -86,7 +86,7 @@ def test_extract_broker_multi_broker(rolling_backend: Backend) -> None:
 def test_derive_consumer_subset(
     task_names: Collection[Task],
     queues: Optional[list[str]],
-    task_specific: bool,
+    task_specific_mode: bool,
     expected: Union[dict[str, list[str]], BaseException],
     rolling_broker: Broker,
 ) -> None:
@@ -102,7 +102,7 @@ def test_derive_consumer_subset(
         actual = _derive_consumer_subset(
             tasks=tasks,
             queues=queues,
-            task_specific=task_specific,
+            task_specific_mode=task_specific_mode,
         )
         if isinstance(expected, dict):
             assert actual == expected
@@ -113,5 +113,5 @@ def test_derive_consumer_subset(
             _derive_consumer_subset(
                 tasks=tasks,
                 queues=queues,
-                task_specific=task_specific,
+                task_specific_mode=task_specific_mode,
             )

--- a/tests/core/worker/test_helpers.py
+++ b/tests/core/worker/test_helpers.py
@@ -40,23 +40,53 @@ def test_extract_broker_multi_broker(rolling_backend: Backend) -> None:
 
 
 @pytest.mark.parametrize(
-    "task_names,queues,expected",
+    "task_names,queues,task_specific,expected",
     [
         # Tasks & no queues specified
-        (["task-1", "task-2"], None, {DEFAULT_QUEUE: ["task-1", "task-2"]}),
-        # Tasks & queues specified
+        (
+            ["task-1", "task-2"],
+            None,
+            True,
+            {DEFAULT_QUEUE: ["task-1", "task-2"]},
+        ),
+        (
+            ["task-1", "task-2"],
+            None,
+            False,
+            [DEFAULT_QUEUE],
+        ),
+        # Tasks & queues both specified
         (
             ["task-1", "task-2"],
             ["queue-b", "queue-a"],
+            True,
             {"queue-a": ["task-2"], "queue-b": ["task-1"]},
         ),
+        (
+            ["task-1", "task-2"],
+            ["queue-b", "queue-a"],
+            False,
+            ["queue-a", "queue-b"],
+        ),
         # Duplicate queues
-        (["task-1", "task-2"], ["queue-a", "queue-a"], ValueError),
+        (
+            ["task-1", "task-2"],
+            ["queue-a", "queue-a"],
+            True,
+            ValueError,
+        ),
+        (
+            ["task-1", "task-2"],
+            ["queue-a", "queue-a"],
+            False,
+            ValueError,
+        ),
     ],
 )
 def test_derive_consumer_subset(
     task_names: Collection[Task],
     queues: Optional[list[str]],
+    task_specific: bool,
     expected: Union[dict[str, list[str]], BaseException],
     rolling_broker: Broker,
 ) -> None:
@@ -68,9 +98,20 @@ def test_derive_consumer_subset(
     else:
         tasks = [_task_factory(n, broker=rolling_broker) for n in task_names]
 
-    if isinstance(expected, dict):
-        actual = _derive_consumer_subset(tasks, queues=queues)
-        assert actual == expected
+    if isinstance(expected, (dict, list)):
+        actual = _derive_consumer_subset(
+            tasks=tasks,
+            queues=queues,
+            task_specific=task_specific,
+        )
+        if isinstance(expected, dict):
+            assert actual == expected
+        else:
+            assert sorted(actual) == sorted(expected)
     else:
         with pytest.raises(expected):
-            _derive_consumer_subset(tasks, queues=queues)
+            _derive_consumer_subset(
+                tasks=tasks,
+                queues=queues,
+                task_specific=task_specific,
+            )


### PR DESCRIPTION
## Overview

This adds a breaking change where the worker pool listens to queues broadly to handle the fact that tasks can now be run on queues other than their default.