### PR TITLE
Replace Task-level priority with Message-level Priority

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev_requirements.txt
+          pip install -e .
+          
+      - name: Deploy documentation
+        run: mkdocs gh-deploy --force 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ['3.9', '3.10']
@@ -35,5 +35,6 @@ jobs:
         pip install -r dev_requirements.txt
         pip install torch==2.3.1
     - name: Test with pytest
+      timeout-minutes: 10
       run: |
         bash tests/run.sh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ capable while remaining very lightweight. Current functionality includes:
 
   * Multiprocess and multi-thread task execution
   * Automatic retries, with customizable backoff procedures
-  * Prioritization of queues, tasks and messages
+  * Prioritization of queues and messages
   * Result storage
   * Status Tracking and Publishing
   * Interactive Result Iteration

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ brew services start redis
 
 ## Quick Start
 
-First, add the following to a file named `quick_start.py`:
+First, add the following to a file named [`tasks.py`](examples/simple/tasks.py):
 
 ```python
 from alsek import Broker, task
@@ -69,23 +69,27 @@ if __name__ == "__main__":
 Running the script will generate an instance of the task.
 
 ```shell
-python quick_start.py
+python tasks.py
 # Task submitted. UUID: e49806be-96ad-11eb-9216-acde48001122.
 ```
 
 Now, we can start up a pool of workers on the command line:
 
 ```shell
-$ alsek quick_start
+$ alsek tasks
 ```
 
 Which will result in output similar to this:
 
 ```shell
-[2021-04-06 10:00:30.250] [MainProcess] [MainThread] [INFO] alsek.core.worker: Alsek v0.0.1 worker pool booting up...
-[2021-04-06 10:00:30.251] [MainProcess] [MainThread] [INFO] alsek.core.worker: Worker pool online.
-[2021-04-06 10:00:30.260] [Process-1] [MainThread] [INFO] alsek.core.worker: Received Message(uuid='e49806be-96ad-11eb-9216-acde48001122', queue='math_ops', task='add')...
-[2021-04-06 10:00:30.261] [Process-1] [MainThread] [INFO] alsek.core.worker: Successfully processed Message(uuid='e49806be-96ad-11eb-9216-acde48001122', queue='math_ops', task='add').
+[2025-04-19 18:30:39.522] [MainProcess] [MainThread] [INFO] alsek.core.worker: Alsek v0.8.0 worker pool booting up...
+[2025-04-19 18:30:39.522] [MainProcess] [MainThread] [INFO] alsek.core.worker: Starting worker pool with 8 max thread(s) and 11 max process(es)...
+[2025-04-19 18:30:39.523] [MainProcess] [MainThread] [INFO] alsek.core.worker: Monitoring 1 queue(s).
+[2025-04-19 18:30:39.523] [MainProcess] [MainThread] [INFO] alsek.core.worker: Worker pool online.
+[2025-04-19 18:30:39.524] [MainProcess] [Thread-2 (_wrapper)] [INFO] alsek.core.futures: Received Message(uuid='bf90af06-1d6d-11f0-affc-4af50920870b', queue='math_ops', task='add')...
+[2025-04-19 18:30:39.524] [MainProcess] [Thread-2 (_wrapper)] [INFO] alsek.core.futures: Successfully processed Message(uuid='bf90af06-1d6d-11f0-affc-4af50920870b', queue='math_ops', task='add').
+[2025-04-19 18:30:39.524] [MainProcess] [Thread-2 (_wrapper)] [INFO] alsek.core.broker: Removing Message(uuid='bf90af06-1d6d-11f0-affc-4af50920870b', queue='math_ops', task='add')...
+[2025-04-19 18:30:39.525] [MainProcess] [Thread-2 (_wrapper)] [INFO] alsek.core.broker: Removed Message(uuid='bf90af06-1d6d-11f0-affc-4af50920870b', queue='math_ops', task='add').
 ```
 
 As we can see above, the message was quickly processed by the worker pool.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ capable while remaining very lightweight. Current functionality includes:
 
   * Multiprocess and multi-thread task execution
   * Automatic retries, with customizable backoff procedures
-  * Prioritization of queues and tasks
+  * Prioritization of queues, tasks and messages
   * Result storage
   * Status Tracking and Publishing
   * Interactive Result Iteration

--- a/alsek/__init__.py
+++ b/alsek/__init__.py
@@ -10,4 +10,4 @@ from alsek.core.message import Message
 from alsek.core.status import StatusTracker
 from alsek.core.task import task
 
-__version__: str = "0.7.3"
+__version__: str = "0.8.0"

--- a/alsek/core/broker.py
+++ b/alsek/core/broker.py
@@ -14,7 +14,11 @@ from alsek.exceptions import MessageAlreadyExistsError, MessageDoesNotExistsErro
 from alsek.storage.backends import Backend
 from alsek.types import Empty
 from alsek.utils.logging import magic_logger
-from alsek.utils.namespacing import get_message_name, get_priority_namespace_from_message, get_dlq_message_name
+from alsek.utils.namespacing import (
+    get_dlq_message_name,
+    get_message_name,
+    get_priority_namespace_from_message,
+)
 from alsek.utils.printing import auto_repr
 
 log = logging.getLogger(__name__)

--- a/alsek/core/broker.py
+++ b/alsek/core/broker.py
@@ -14,7 +14,7 @@ from alsek.exceptions import MessageAlreadyExistsError, MessageDoesNotExistsErro
 from alsek.storage.backends import Backend
 from alsek.types import Empty
 from alsek.utils.logging import magic_logger
-from alsek.utils.namespacing import get_message_name, get_priority_name, get_dlq_message_name
+from alsek.utils.namespacing import get_message_name, get_priority_namespace, get_dlq_message_name
 from alsek.utils.printing import auto_repr
 
 log = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class Broker:
             raise MessageAlreadyExistsError(f"'{name}' found in backend")
 
         self.backend.priority_add(
-            get_priority_name(message),
+            get_priority_namespace(message),
             member=message.uuid,
             priority=message.priority,
         )

--- a/alsek/core/broker.py
+++ b/alsek/core/broker.py
@@ -14,7 +14,7 @@ from alsek.exceptions import MessageAlreadyExistsError, MessageDoesNotExistsErro
 from alsek.storage.backends import Backend
 from alsek.types import Empty
 from alsek.utils.logging import magic_logger
-from alsek.utils.namespacing import get_message_name, get_priority_namespace, get_dlq_message_name
+from alsek.utils.namespacing import get_message_name, get_priority_namespace_from_message, get_dlq_message_name
 from alsek.utils.printing import auto_repr
 
 log = logging.getLogger(__name__)
@@ -83,8 +83,8 @@ class Broker:
             raise MessageAlreadyExistsError(f"'{name}' found in backend")
 
         self.backend.priority_add(
-            get_priority_namespace(message),
-            unique_id=message.uuid,
+            get_priority_namespace_from_message(message),
+            unique_id=name,
             priority=message.priority,
         )
 
@@ -137,6 +137,10 @@ class Broker:
             None
 
         """
+        self.backend.priority_remove(
+            key=get_priority_namespace_from_message(message),
+            unique_id=get_message_name(message),
+        )
         self.backend.delete(get_message_name(message), missing_ok=True)
         self._clear_lock(message)
 

--- a/alsek/core/broker.py
+++ b/alsek/core/broker.py
@@ -84,7 +84,7 @@ class Broker:
 
         self.backend.priority_add(
             get_priority_namespace(message),
-            member=message.uuid,
+            unique_id=message.uuid,
             priority=message.priority,
         )
 

--- a/alsek/core/consumer.py
+++ b/alsek/core/consumer.py
@@ -11,6 +11,7 @@ from alsek.core.broker import Broker
 from alsek.core.concurrency import Lock
 from alsek.core.message import Message
 from alsek.storage.backends import Backend
+from alsek.utils.namespacing import get_subnamespace
 from alsek.utils.system import StopSignalListener
 
 
@@ -85,12 +86,12 @@ class Consumer:
 
     def _scan_subnamespaces(self) -> Iterable[str]:
         if not self.subset:
-            subnamespaces = [self.broker.get_subnamespace(None)]
+            subnamespaces = [get_subnamespace(None)]
         elif isinstance(self.subset, list):
-            subnamespaces = [self.broker.get_subnamespace(q) for q in self.subset]
+            subnamespaces = [get_subnamespace(q) for q in self.subset]
         else:
             subnamespaces = [
-                self.broker.get_subnamespace(q, task_name=t)
+                get_subnamespace(q, task_name=t)
                 for (q, tasks) in self.subset.items()
                 for t in tasks
             ]

--- a/alsek/core/consumer.py
+++ b/alsek/core/consumer.py
@@ -100,6 +100,12 @@ class Consumer:
             yield from self.broker.backend.scan(f"{get_priority_namespace(s)}*")
 
     def _poll(self) -> list[Message]:
+        # NOTE: with this approach, we 'drain' / exhaust queues in
+        #       the order they're privided, and then drain the next.
+        #       So if we had queues A,B,C we'd drain A, then drain B
+        #       and, finally, drain C.
+        # ToDo: implement a 'flat' option that moves to the next queue
+        #       So, A then B then C, round and round.
         output: list[Message] = list()
         for s in self._scan_subnamespaces():
             for name in self.broker.backend.priority_iter(s):

--- a/alsek/core/consumer.py
+++ b/alsek/core/consumer.py
@@ -11,7 +11,7 @@ from alsek.core.broker import Broker
 from alsek.core.concurrency import Lock
 from alsek.core.message import Message
 from alsek.storage.backends import Backend
-from alsek.utils.namespacing import get_subnamespace, get_priority_namespace
+from alsek.utils.namespacing import get_priority_namespace, get_subnamespace
 from alsek.utils.system import StopSignalListener
 
 

--- a/alsek/core/consumer.py
+++ b/alsek/core/consumer.py
@@ -106,7 +106,7 @@ class Consumer:
                 message_data = self.broker.backend.get(name)
                 if message_data is None:
                     # Message data can be None if it has been deleted (by a TTL or
-                    # another worker) between the `priority_get()` and `get()` operations.
+                    # another worker) between the `priority_iter()` and `get()` operations.
                     continue
 
                 message = Message(**message_data)

--- a/alsek/core/futures.py
+++ b/alsek/core/futures.py
@@ -155,7 +155,9 @@ class TaskFuture(ABC):
     def _revocation_scan(self, check_interval: int | float = 0.5) -> None:
         while not self.complete and not self._revocation_stop_event.is_set():
             if self.task.is_revoked(self.message):
-                log.info("Evicting '%s' due to task revocation...", self.message.summary)
+                log.info(
+                    "Evicting '%s' due to task revocation...", self.message.summary
+                )
                 self.stop(RevokedError)
                 log.info("Evicted '%s'.", self.message.summary)
                 break

--- a/alsek/core/message.py
+++ b/alsek/core/message.py
@@ -45,8 +45,6 @@ class Message:
             the task's function during the execution of ``op()``
         priority (int): priority of the message within the task.
             Messages with lower values will be executed before messages with higher values.
-            Note that messages belonging to tasks with higher priority (lower value) will be
-            executed before messages belong to tasks with lower priority (higher value).
         metadata (dict, optional): a dictionary of user-defined message metadata.
             This can store any data types supported by the backend's serializer.
         exception_details (dict, optional): information about any exception raised

--- a/alsek/core/message.py
+++ b/alsek/core/message.py
@@ -105,7 +105,7 @@ class Message:
         previous_result: Optional[Any] = None,
         previous_message_uuid: Optional[str] = None,
         callback_message_data: Optional[dict[str, Any]] = None,
-        backoff_settings: Optional[dict[str, int]] = None,
+        backoff_settings: Optional[dict[str, Any]] = None,
         mechanism: SupportedMechanismType = DEFAULT_MECHANISM,
     ) -> None:
         self.task_name = task_name

--- a/alsek/core/message.py
+++ b/alsek/core/message.py
@@ -43,6 +43,10 @@ class Message:
             the task's function during the execution of ``op()``
         kwargs (dict, optional): keyword arguments to pass to
             the task's function during the execution of ``op()``
+        priority (int): priority of the message within the task.
+            Messages with lower values will be executed before messages with higher values.
+            Note that messages belonging to tasks with higher priority (lower value) will be
+            executed before messages belong to tasks with lower priority (higher value).
         metadata (dict, optional): a dictionary of user-defined message metadata.
             This can store any data types supported by the backend's serializer.
         exception_details (dict, optional): information about any exception raised
@@ -89,6 +93,7 @@ class Message:
         queue: Optional[str] = None,
         args: Optional[Union[list[Any], tuple[Any, ...]]] = None,
         kwargs: Optional[dict[Any, Any]] = None,
+        priority: int = 0,
         metadata: Optional[dict[Any, Any]] = None,
         exception_details: Optional[Union[dict[str, Any], ExceptionDetails]] = None,
         result_ttl: Optional[int] = None,
@@ -109,6 +114,7 @@ class Message:
         self.queue = queue or DEFAULT_QUEUE
         self.args = tuple(args) if args else tuple()
         self.kwargs = kwargs or dict()
+        self.priority = priority
         self.metadata = metadata
         self._exception_details = exception_details
         self.result_ttl = result_ttl
@@ -163,6 +169,7 @@ class Message:
             queue=self.queue,
             args=self.args,
             kwargs=self.kwargs,
+            priority=self.priority,
             metadata=self.metadata,
             exception_details=(
                 None

--- a/alsek/core/status.py
+++ b/alsek/core/status.py
@@ -178,8 +178,8 @@ class StatusTracker:
         for i in self.broker.backend.sub(self.get_pubsub_name(message)):
             if i.get("type", "").lower() == "message":
                 update = StatusUpdate(
-                    status=TaskStatus[i["data"]["status"]],
-                    details=i["data"]["details"],
+                    status=TaskStatus[i["data"]["status"]],  # noqa
+                    details=i["data"]["details"],  # noqa
                 )
                 yield update
                 if auto_exit and update.status in TERMINAL_TASK_STATUSES:
@@ -222,10 +222,13 @@ class StatusTracker:
 
         """
         value = self._backend.get(self.get_storage_name(message))
-        return StatusUpdate(
-            status=TaskStatus[value["status"]],
-            details=value["details"],
-        )
+        if value:
+            return StatusUpdate(
+                status=TaskStatus[value["status"]],  # noqa
+                details=value["details"],
+            )
+        else:
+            raise KeyError(f"No status found for message '{message.summary}'")
 
     def delete(self, message: Message, check: bool = True) -> None:
         """Delete the status of ``message``.

--- a/alsek/core/status.py
+++ b/alsek/core/status.py
@@ -221,8 +221,7 @@ class StatusTracker:
             status (StatusUpdate): the status of ``message``
 
         """
-        value = self._backend.get(self.get_storage_name(message))
-        if value:
+        if value := self._backend.get(self.get_storage_name(message)):
             return StatusUpdate(
                 status=TaskStatus[value["status"]],  # noqa
                 details=value["details"],

--- a/alsek/core/task.py
+++ b/alsek/core/task.py
@@ -720,7 +720,6 @@ def task(
     broker: Broker,
     name: Optional[str] = None,
     queue: Optional[str] = None,
-    priority: int = 0,
     timeout: int = DEFAULT_TASK_TIMEOUT,
     max_retries: Optional[int] = DEFAULT_MAX_RETRIES,
     backoff: Optional[Backoff] = ExponentialBackoff(),
@@ -739,8 +738,6 @@ def task(
             the class name will be used.
         queue (str, optional): the name of the queue to generate the task on.
             If ``None``, the default queue will be used.
-        priority (int): priority of the task. Tasks with lower values
-            will be executed before tasks with higher values.
         timeout (int): the maximum amount of time (in milliseconds)
             this task is permitted to run.
         max_retries (int, optional): maximum number of allowed retries

--- a/alsek/core/task.py
+++ b/alsek/core/task.py
@@ -29,7 +29,7 @@ from alsek._defaults import (
 from alsek.core.backoff import Backoff, ConstantBackoff, ExponentialBackoff
 from alsek.core.broker import Broker
 from alsek.core.message import Message
-from alsek.core.status import StatusTracker, TaskStatus, TERMINAL_TASK_STATUSES
+from alsek.core.status import TERMINAL_TASK_STATUSES, StatusTracker, TaskStatus
 from alsek.exceptions import RevokedError, SchedulingError, ValidationError
 from alsek.storage.result import ResultStore
 from alsek.types import SUPPORTED_MECHANISMS, SupportedMechanismType
@@ -404,7 +404,9 @@ class Task:
 
         """
 
-    def on_revocation(self, message: Message, exception: Optional[BaseException], result: Any) -> None:
+    def on_revocation(
+        self, message: Message, exception: Optional[BaseException], result: Any
+    ) -> None:
         """Handles the event when a message is revoked and logs the associated exception.
 
         Args:

--- a/alsek/core/task.py
+++ b/alsek/core/task.py
@@ -35,6 +35,7 @@ from alsek.storage.result import ResultStore
 from alsek.types import SUPPORTED_MECHANISMS, SupportedMechanismType
 from alsek.utils.aggregation import gather_init_params
 from alsek.utils.logging import magic_logger
+from alsek.utils.namespacing import get_message_name
 from alsek.utils.parsing import ExceptionDetails, get_exception_name
 from alsek.utils.printing import auto_repr
 
@@ -512,8 +513,9 @@ class Task:
         """
         return True
 
-    def _make_revoked_key_name(self, message: Message) -> str:
-        return f"revoked:{self.broker.get_message_name(message)}"
+    @staticmethod
+    def _make_revoked_key_name(message: Message) -> str:
+        return f"revoked:{get_message_name(message)}"
 
     @magic_logger(
         before=lambda message: log.info("Revoking %s...", message.summary),

--- a/alsek/core/task.py
+++ b/alsek/core/task.py
@@ -276,6 +276,7 @@ class Task:
         self,
         args: Optional[Union[list[Any], tuple[Any, ...]]] = None,
         kwargs: Optional[dict[Any, Any]] = None,
+        priority: int = 0,
         metadata: Optional[dict[Any, Any]] = None,
         result_ttl: Optional[int] = None,
         uuid: Optional[str] = None,
@@ -295,6 +296,10 @@ class Task:
         Args:
             args (list, tuple, optional): positional arguments to pass to ``function``
             kwargs (dict, optional): keyword arguments to pass to ``function``
+            priority (int): priority of the message within the task.
+                Messages with lower values will be executed before messages with higher values.
+                Note that messages belonging to tasks with higher priority (lower value) will be
+                executed before messages belong to tasks with lower priority (higher value).
             metadata (dict, optional): a dictionary of user-defined message metadata.
                 This can store any data types supported by the backend's serializer.
             result_ttl (int, optional): time to live (in milliseconds) for the
@@ -339,6 +344,7 @@ class Task:
             queue=queue or self.queue,
             args=args,
             kwargs=kwargs,
+            priority=priority,
             metadata=metadata,
             result_ttl=result_ttl,
             uuid=uuid,

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -4,6 +4,8 @@
 
 """
 
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
 from typing import Any, Collection, DefaultDict, Optional

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -224,7 +224,7 @@ class WorkerPool(Consumer):
         log.info(
             "Monitoring %s %s.",
             len(self.tasks) if self.task_specific_mode else len(self.queues),
-            "tasks" if self.task_specific_mode else "queues",
+            "task(s)" if self.task_specific_mode else "queue(s)",
         )
         log.info("Worker pool online.")
 

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -55,7 +55,7 @@ def _derive_consumer_subset(
         return queues
 
     subset: DefaultDict[str, list[str]] = defaultdict(list)
-    for t in sorted(tasks, key=lambda i: i.priority):
+    for t in tasks:
         if queues is None or t.queue in queues:
             subset[t.queue].append(t.name)
 

--- a/alsek/storage/backends/__init__.py
+++ b/alsek/storage/backends/__init__.py
@@ -213,6 +213,9 @@ class BaseBackend(ABC):
             unique_id (str): The item's (Message's) unique identifier
             priority (float): The numeric priority score (decide if lower or higher means higher priority).
 
+        Returns:
+            None
+
         """
         raise NotImplementedError()
 

--- a/alsek/storage/backends/__init__.py
+++ b/alsek/storage/backends/__init__.py
@@ -205,12 +205,12 @@ class BaseBackend(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def priority_add(self, key: str, member: str, priority: int | float) -> None:
+    def priority_add(self, key: str, unique_id: str, priority: int | float) -> None:
         """Add an item to a priority-sorted set.
 
         Args:
             key (str): The name of the sorted set.
-            member (str): The item's identifier or value.
+            unique_id (str): The item's (Message's) unique identifier
             priority (float): The numeric priority score (decide if lower or higher means higher priority).
 
         """

--- a/alsek/storage/backends/__init__.py
+++ b/alsek/storage/backends/__init__.py
@@ -204,6 +204,31 @@ class BaseBackend(ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def priority_add(self, key: str, member: str, priority: int | float) -> None:
+        """Add an item to a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+            member (str): The item's identifier or value.
+            priority (float): The numeric priority score (decide if lower or higher means higher priority).
+
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def priority_get(self, key: str) -> Optional[str]:
+        """
+        Get (peek) the highest-priority item without removing it.
+
+        Args:
+            key (str): The name of the sorted set.
+
+        Returns:
+            str | None: The member with the highest priority, or None if empty.
+        """
+        raise NotImplementedError()
+
     def pub(self, channel: str, value: Any) -> None:
         """Publish to a channel.
 

--- a/alsek/storage/backends/__init__.py
+++ b/alsek/storage/backends/__init__.py
@@ -228,7 +228,20 @@ class BaseBackend(ABC):
             key (str): The name of the sorted set.
 
         Returns:
-            str | None: The member with the highest priority, or None if empty.
+            item (str, optional): The member with the highest priority, or None if empty.
+
+        """
+        raise NotImplementedError()
+
+    def priority_iter(self, key: str) -> Iterable[str]:
+        """Iterate over the items in a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+
+        Returns:
+            priority (Iterable[str]): An iterable of members in the sorted set, sorted by priority.
+
         """
         raise NotImplementedError()
 

--- a/alsek/storage/backends/__init__.py
+++ b/alsek/storage/backends/__init__.py
@@ -229,6 +229,20 @@ class BaseBackend(ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def priority_remove(self, key: str, unique_id: str) -> None:
+        """Remove an item from a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+            unique_id (str): The item's (Message's) unique identifier
+
+        Returns:
+            None
+
+        """
+        raise NotImplementedError()
+
     def pub(self, channel: str, value: Any) -> None:
         """Publish to a channel.
 

--- a/alsek/storage/backends/disk/__init__.py
+++ b/alsek/storage/backends/disk/__init__.py
@@ -3,4 +3,5 @@
     Disk
 
 """
+
 from alsek.storage.backends.disk.standard import DiskCacheBackend

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -239,6 +239,20 @@ class DiskCacheBackend(Backend):
             (top_key, *_) = min(options, key=lambda x: x[1])
         return top_key
 
+    def priority_iter(self, key: str) -> Iterable[str]:
+        """Iterate over the items in a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+
+        Returns:
+            priority (Iterable[str]): An iterable of members in the sorted set, sorted by priority.
+
+        """
+        entries = [(k, self.get(k)) for k in self.scan(f"{key}:*")]
+        for k, _ in sorted(entries, key=lambda x: x[1]):
+            yield k
+
     def priority_remove(self, key: str, unique_id: str) -> None:
         """Remove an item from a priority-sorted set.
 

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -206,12 +206,12 @@ class DiskCacheBackend(Backend):
             if self.name_match_func(pattern, short_name):
                 yield short_name
 
-    def priority_add(self, key: str, member: str, priority: int | float) -> None:
+    def priority_add(self, key: str, unique_id: str, priority: int | float) -> None:
         """Add an item to a priority-sorted set.
 
         Args:
             key (str): The name of the sorted set.
-            member (str): The item's identifier or value.
+            unique_id (str): The item's (Message's) unique identifier
             priority (float): The numeric priority score (decide if lower or higher means higher priority).
 
         Returns:
@@ -219,7 +219,7 @@ class DiskCacheBackend(Backend):
 
         """
         self.set(
-            f"{key}:{member}",
+            f"{key}:{unique_id}",
             value=priority,
             nx=False,  # i.e., overwrite any existing priority
         )

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -205,3 +205,36 @@ class DiskCacheBackend(Backend):
             short_name = self.short_name(name)
             if self.name_match_func(pattern, short_name):
                 yield short_name
+
+    def priority_add(self, key: str, member: str, priority: int | float) -> None:
+        """Add an item to a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+            member (str): The item's identifier or value.
+            priority (float): The numeric priority score (decide if lower or higher means higher priority).
+
+        Returns:
+            None
+
+        """
+        self.set(
+            f"{key}:{member}",
+            value=priority,
+            nx=False,  # i.e., overwrite any existing priority
+        )
+
+    def priority_get(self, key: str) -> Optional[str]:
+        """Get (peek) the highest-priority item without removing it.
+
+        Args:
+            key (str): The name of the sorted set.
+
+        Returns:
+            str | None: The member with the highest priority, or None if empty.
+
+        """
+        top_key = None
+        if options := [(k, self.get(k)) for k in self.scan(f"{key}:*")]:
+            (top_key, *_) = min(options, key=lambda x: x[1])
+        return top_key

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -3,6 +3,7 @@
     Disk Backend
 
 """
+
 from __future__ import annotations
 
 import shutil

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -238,3 +238,19 @@ class DiskCacheBackend(Backend):
         if options := [(k, self.get(k)) for k in self.scan(f"{key}:*")]:
             (top_key, *_) = min(options, key=lambda x: x[1])
         return top_key
+
+    def priority_remove(self, key: str, unique_id: str) -> None:
+        """Remove an item from a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+            unique_id (str): The item's (Message's) unique identifier
+
+        Returns:
+            None
+
+        """
+        self.delete(
+            f"{key}:{unique_id}",
+            missing_ok=True,
+        )

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -61,7 +61,7 @@ class DiskCacheBackend(Backend):
     @staticmethod
     def _conn_parse(
         conn: Optional[Union[str, Path, DiskCache, LazyClient]]
-    ) -> Union[DiskCache, Callable[[], DiskCache]]:
+    ) -> Union[DiskCache, LazyClient, Callable[[], DiskCache]]:
         if isinstance(conn, LazyClient):
             return conn
 

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -3,6 +3,7 @@
     Disk Backend
 
 """
+from __future__ import annotations
 
 import shutil
 from pathlib import Path

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -42,8 +42,8 @@ class DiskCacheBackend(Backend):
     Warning:
         ``DiskCache`` persists data to a local (Sqlite) database and does
         not implement 'server-side' "if not exist" on `SET` (`nx`) support or
-        true priority capabilies. For these reasons, ``DiskCacheBackend()`` is
-        recommended for development and testing purposes only. (Mulit-worker setups
+        true priority capabilities. For these reasons, ``DiskCacheBackend()`` is
+        recommended for development and testing purposes only. (Multi-worker setups
         in particular should not be used with this backend.)
 
     """

--- a/alsek/storage/backends/disk/standard.py
+++ b/alsek/storage/backends/disk/standard.py
@@ -231,7 +231,7 @@ class DiskCacheBackend(Backend):
             key (str): The name of the sorted set.
 
         Returns:
-            str | None: The member with the highest priority, or None if empty.
+            top key (str, optional): The member with the highest priority, or None if empty.
 
         """
         top_key = None

--- a/alsek/storage/backends/redis/__init__.py
+++ b/alsek/storage/backends/redis/__init__.py
@@ -3,5 +3,6 @@
     Redis
 
 """
-from alsek.storage.backends.redis.standard import RedisBackend
+
 from alsek.storage.backends.redis.asyncio import RedisAsyncBackend
+from alsek.storage.backends.redis.standard import RedisBackend

--- a/alsek/storage/backends/redis/asyncio.py
+++ b/alsek/storage/backends/redis/asyncio.py
@@ -5,14 +5,15 @@
 """
 
 from __future__ import annotations
+
 import logging
 from typing import Any, AsyncIterable, Optional, Type, Union
 
-from redis.asyncio import Redis as RedisAsync
-from redis.asyncio import ConnectionPool as AsyncConnectionPool
-
 import dill
-from alsek.storage.backends import LazyClient, AsyncBackend
+from redis.asyncio import ConnectionPool as AsyncConnectionPool
+from redis.asyncio import Redis as RedisAsync
+
+from alsek.storage.backends import AsyncBackend, LazyClient
 from alsek.storage.backends.redis.standard import parse_sub_data
 from alsek.types import Empty
 from alsek.utils.aggregation import gather_init_params

--- a/alsek/storage/backends/redis/standard.py
+++ b/alsek/storage/backends/redis/standard.py
@@ -188,14 +188,32 @@ class RedisBackend(Backend):
             raise KeyError(f"No name '{name}' found")
 
     def priority_add(self, key: str, unique_id: str, priority: int | float) -> None:
-        """Add an item to a priority-sorted set."""
+        """Add an item to a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+            unique_id (str): The item's (Message's) unique identifier
+            priority (float): The numeric priority score (decide if lower or higher means higher priority).
+
+        Returns:
+            None
+
+        """
         self.conn.zadd(
             self.full_name(key),
             mapping={unique_id: priority},
         )
 
     def priority_get(self, key: str) -> Optional[str]:
-        """Get (peek) the highest-priority item without removing it."""
+        """Get (peek) the highest-priority item without removing it.
+
+        Args:
+            key (str): The name of the sorted set.
+
+        Returns:
+            item (str, optional): The member with the highest priority, or None if empty.
+
+        """
         results: list[str] = self.conn.zrange(
             self.full_name(key),
             start=0,
@@ -204,7 +222,16 @@ class RedisBackend(Backend):
         return results[0] if results else None
 
     def priority_remove(self, key: str, unique_id: str) -> None:
-        """Remove an item from a priority-sorted-set"""
+        """Remove an item from a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+            unique_id (str): The item's (Message's) unique identifier
+
+        Returns:
+            None
+
+        """
         self.conn.zrem(
             self.full_name(key),
             unique_id,

--- a/alsek/storage/backends/redis/standard.py
+++ b/alsek/storage/backends/redis/standard.py
@@ -187,6 +187,22 @@ class RedisBackend(Backend):
         if not missing_ok and not found:
             raise KeyError(f"No name '{name}' found")
 
+    def priority_add(self, key: str, member: str, priority: int | float) -> None:
+        """Add an item to a priority-sorted set."""
+        self.conn.zadd(
+            self.full_name(key),
+            mapping={member: priority},
+        )
+
+    def priority_get(self, key: str) -> Optional[str]:
+        """Get (peek) the highest-priority item without removing it."""
+        results: list[str] = self.conn.zrange(
+            self.full_name(key),
+            start=0,
+            end=0,
+        )
+        return results[0] if results else None
+
     def pub(self, channel: str, value: Any) -> None:
         self.conn.publish(
             channel=channel,

--- a/alsek/storage/backends/redis/standard.py
+++ b/alsek/storage/backends/redis/standard.py
@@ -187,11 +187,11 @@ class RedisBackend(Backend):
         if not missing_ok and not found:
             raise KeyError(f"No name '{name}' found")
 
-    def priority_add(self, key: str, member: str, priority: int | float) -> None:
+    def priority_add(self, key: str, unique_id: str, priority: int | float) -> None:
         """Add an item to a priority-sorted set."""
         self.conn.zadd(
             self.full_name(key),
-            mapping={member: priority},
+            mapping={unique_id: priority},
         )
 
     def priority_get(self, key: str) -> Optional[str]:

--- a/alsek/storage/backends/redis/standard.py
+++ b/alsek/storage/backends/redis/standard.py
@@ -203,6 +203,13 @@ class RedisBackend(Backend):
         )
         return results[0] if results else None
 
+    def priority_remove(self, key: str, unique_id: str) -> None:
+        """Remove an item from a priority-sorted-set"""
+        self.conn.zrem(
+            self.full_name(key),
+            unique_id,
+        )
+
     def pub(self, channel: str, value: Any) -> None:
         self.conn.publish(
             channel=channel,

--- a/alsek/storage/backends/redis/standard.py
+++ b/alsek/storage/backends/redis/standard.py
@@ -221,6 +221,18 @@ class RedisBackend(Backend):
         )
         return results[0] if results else None
 
+    def priority_iter(self, key: str) -> Iterable[str]:
+        """Iterate over the items in a priority-sorted set.
+
+        Args:
+            key (str): The name of the sorted set.
+
+        Returns:
+            priority (Iterable[str]): An iterable of members in the sorted set, sorted by priority.
+
+        """
+        yield from self.conn.zrange(self.full_name(key), 0, -1)
+
     def priority_remove(self, key: str, unique_id: str) -> None:
         """Remove an item from a priority-sorted set.
 

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -3,6 +3,7 @@
     Namespacing
 
 """
+
 from typing import Optional
 
 from alsek.core.message import Message

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -94,8 +94,8 @@ def get_priority_namespace_from_message(message: Message) -> str:
         str: the fully qualified priority queue name
 
     """
-    subnamespace = get_subnamespace(message.queue)
-    return f"{get_priority_namespace(subnamespace)}:{TASK_NAMESPACE_KEY}:{message.task_name}"
+    subnamespace = get_subnamespace(message.queue, message.task_name)
+    return get_priority_namespace(subnamespace)
 
 
 def get_dlq_message_name(message: Message) -> str:

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 from alsek.core.message import Message
 
+MESSAGES_NAMESPACE = "messages"
+PRIORITY_NAMESPACE = "priority"
 
 def get_subnamespace(
     queue: Optional[str] = None,
@@ -48,7 +50,7 @@ def get_messages_namespace(message: Message) -> str:
 
     """
     subnamespace = get_subnamespace(message.queue, message.task_name)
-    return f"{subnamespace}:messages"
+    return f"{subnamespace}:{MESSAGES_NAMESPACE}"
 
 
 def get_message_name(message: Message) -> str:
@@ -75,7 +77,7 @@ def get_priority_namespace(message: Message) -> str:
         str: the fully qualified priority queue name
     """
     subnamespace = get_subnamespace(message.queue, message.task_name)
-    return f"{subnamespace}:priority"
+    return f"{subnamespace}:{PRIORITY_NAMESPACE}"
 
 
 def get_dlq_message_name(message: Message) -> str:

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -5,7 +5,7 @@
 """
 from typing import Optional
 
-from alsek import Message
+from alsek.core.message import Message
 
 
 def get_subnamespace(

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -7,8 +7,9 @@ from typing import Optional
 
 from alsek.core.message import Message
 
-MESSAGES_NAMESPACE = "messages"
-PRIORITY_NAMESPACE = "priority"
+MESSAGES_NAMESPACE: str = "messages"
+PRIORITY_NAMESPACE: str = "priority"
+
 
 def get_subnamespace(
     queue: Optional[str] = None,

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -37,6 +37,20 @@ def get_subnamespace(
         return "queues"
 
 
+def get_messages_namespace(message: Message) -> str:
+    """Get the namespace for a message.
+
+    Args:
+        message (Message): an Alsek message
+
+    Returns:
+        namespace (str): the namespace for the message
+
+    """
+    subnamespace = get_subnamespace(message.queue, message.task_name)
+    return f"{subnamespace}:messages"
+
+
 def get_message_name(message: Message) -> str:
     """Get the name for ``message`` in the backend.
 
@@ -47,8 +61,8 @@ def get_message_name(message: Message) -> str:
         name (str): message-specific name
 
     """
-    subnamespace = get_subnamespace(message.queue, message.task_name)
-    return f"{subnamespace}:messages:{message.uuid}"
+    subnamespace = get_messages_namespace(message)
+    return f"{subnamespace}:{message.uuid}"
 
 
 def get_priority_namespace(message: Message) -> str:

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -91,7 +91,7 @@ def get_priority_namespace_from_message(message: Message) -> str:
         message (Message): an Alsek message
 
     Returns:
-        str: the fully qualified priority queue name
+        namespace (str): the fully-qualified priority queue name
 
     """
     subnamespace = get_subnamespace(message.queue, message.task_name)

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -9,6 +9,7 @@ from alsek.core.message import Message
 
 MESSAGES_NAMESPACE_KEY: str = "messages"
 PRIORITY_NAMESPACE_KEY: str = "priority"
+DLQ_NAMESPACE_KEY: str = "dlq"
 
 
 def get_subnamespace(
@@ -91,4 +92,4 @@ def get_dlq_message_name(message: Message) -> str:
         dlq_name (str): message-specific name in the DLQ
 
     """
-    return f"dtq:{get_message_name(message)}"
+    return f"{DLQ_NAMESPACE_KEY}:{get_message_name(message)}"

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 from alsek.core.message import Message
 
+QUEUES_NAMESPACE_KEY: str = "queues"
+TASK_NAMESPACE_KEY: str = "tasks"
 MESSAGES_NAMESPACE_KEY: str = "messages"
 PRIORITY_NAMESPACE_KEY: str = "priority"
 DLQ_NAMESPACE_KEY: str = "dlq"
@@ -34,11 +36,11 @@ def get_subnamespace(
         raise ValueError("`queue` must be provided if `task_name` is not None")
 
     if queue and task_name:
-        return f"queues:{queue}:tasks:{task_name}"
+        return f"{QUEUES_NAMESPACE_KEY}:{queue}:{TASK_NAMESPACE_KEY}:{task_name}"
     elif queue:
-        return f"queues:{queue}"
+        return f"{QUEUES_NAMESPACE_KEY}:{queue}"
     else:
-        return "queues"
+        return f"{QUEUES_NAMESPACE_KEY}"
 
 
 def get_messages_namespace(message: Message) -> str:
@@ -69,7 +71,20 @@ def get_message_name(message: Message) -> str:
     return f"{subnamespace}:{message.uuid}"
 
 
-def get_priority_namespace(message: Message) -> str:
+def get_priority_namespace(subnamespace: str) -> str:
+    """Get the namespace for a message's priority information.
+
+    Args:
+        subnamespace (str): the namespace for the message
+
+    Returns:
+        priority_namespace (str): the namespace for priority information
+
+    """
+    return f"{PRIORITY_NAMESPACE_KEY}:{subnamespace}"
+
+
+def get_priority_namespace_from_message(message: Message) -> str:
     """Get the namespace for message's priority information.
 
     Args:
@@ -77,9 +92,10 @@ def get_priority_namespace(message: Message) -> str:
 
     Returns:
         str: the fully qualified priority queue name
+
     """
-    subnamespace = get_subnamespace(message.queue, message.task_name)
-    return f"{subnamespace}:{PRIORITY_NAMESPACE_KEY}"
+    subnamespace = get_subnamespace(message.queue)
+    return f"{get_priority_namespace(subnamespace)}:{TASK_NAMESPACE_KEY}:{message.task_name}"
 
 
 def get_dlq_message_name(message: Message) -> str:

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -7,8 +7,8 @@ from typing import Optional
 
 from alsek.core.message import Message
 
-MESSAGES_NAMESPACE: str = "messages"
-PRIORITY_NAMESPACE: str = "priority"
+MESSAGES_NAMESPACE_KEY: str = "messages"
+PRIORITY_NAMESPACE_KEY: str = "priority"
 
 
 def get_subnamespace(
@@ -51,7 +51,7 @@ def get_messages_namespace(message: Message) -> str:
 
     """
     subnamespace = get_subnamespace(message.queue, message.task_name)
-    return f"{subnamespace}:{MESSAGES_NAMESPACE}"
+    return f"{subnamespace}:{MESSAGES_NAMESPACE_KEY}"
 
 
 def get_message_name(message: Message) -> str:
@@ -78,7 +78,7 @@ def get_priority_namespace(message: Message) -> str:
         str: the fully qualified priority queue name
     """
     subnamespace = get_subnamespace(message.queue, message.task_name)
-    return f"{subnamespace}:{PRIORITY_NAMESPACE}"
+    return f"{subnamespace}:{PRIORITY_NAMESPACE_KEY}"
 
 
 def get_dlq_message_name(message: Message) -> str:

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -66,7 +66,7 @@ def get_message_name(message: Message) -> str:
 
 
 def get_priority_namespace(message: Message) -> str:
-    """Get the priority queue name for a message's queue.
+    """Get the namespace for message's priority information.
 
     Args:
         message (Message): an Alsek message

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -1,0 +1,77 @@
+"""
+
+    Namespacing
+
+"""
+from typing import Optional
+
+from alsek import Message
+
+
+def get_subnamespace(
+    queue: Optional[str] = None,
+    task_name: Optional[str] = None,
+) -> str:
+    """Get the subnamespace for a given ``queue``
+    and (optionally) ``task_name``.
+
+    Args:
+        queue (str, optional): the name of the queue
+        task_name (str): name of the task
+
+    Returns:
+        subnamespace (str): queue-specific namespace
+
+    Raises:
+        ValueError: if ``task_name`` is provided and ``queue`` is not.
+
+    """
+    if queue is None and task_name is not None:
+        raise ValueError("`queue` must be provided if `task_name` is not None")
+
+    if queue and task_name:
+        return f"queues:{queue}:tasks:{task_name}"
+    elif queue:
+        return f"queues:{queue}"
+    else:
+        return "queues"
+
+
+def get_message_name(message: Message) -> str:
+    """Get the name for ``message`` in the backend.
+
+    Args:
+        message (Message): an Alsek message
+
+    Returns:
+        name (str): message-specific name
+
+    """
+    subnamespace = get_subnamespace(message.queue, message.task_name)
+    return f"{subnamespace}:messages:{message.uuid}"
+
+
+def get_priority_name(message: Message) -> str:
+    """Get the priority queue name for a message's queue.
+
+    Args:
+        message (Message): an Alsek message
+
+    Returns:
+        str: the fully qualified priority queue name
+    """
+    subnamespace = get_subnamespace(message.queue, message.task_name)
+    return f"{subnamespace}:priority"
+
+
+def get_dlq_message_name(message: Message) -> str:
+    """Get the name for ``message`` in the backend's dead letter queue (DLQ).
+
+    Args:
+        message (Message): an Alsek message
+
+    Returns:
+        dlq_name (str): message-specific name in the DLQ
+
+    """
+    return f"dtq:{get_message_name(message)}"

--- a/alsek/utils/namespacing.py
+++ b/alsek/utils/namespacing.py
@@ -51,7 +51,7 @@ def get_message_name(message: Message) -> str:
     return f"{subnamespace}:messages:{message.uuid}"
 
 
-def get_priority_name(message: Message) -> str:
+def get_priority_namespace(message: Message) -> str:
     """Get the priority queue name for a message's queue.
 
     Args:

--- a/alsek/utils/parsing.py
+++ b/alsek/utils/parsing.py
@@ -5,6 +5,7 @@
 """
 
 from __future__ import annotations
+
 import builtins
 import traceback
 from importlib import import_module

--- a/docs/guided_tour.md
+++ b/docs/guided_tour.md
@@ -260,10 +260,7 @@ def my_task() -> int:
 
 ### Priority
 
-As with timeouts, priority values can be set for each task.
-
-Alsek implements _intra-queue_ message priority. In other words, priority 
-is enforced within, but not between, queues (which themselves can be prioritized).
+As with timeouts, priority values can be set for each message.
 
 Let's take a look at an example.
 
@@ -281,6 +278,10 @@ message_2 = task_a.generate(priority=0)
 In Alsek, `priority` is inverted. That is, lower integers correspond to higher priority.
 Thus, in the example above, `message_2` will take priority over 
 instances of `message_1`.
+
+!!! note
+    Alsek implements _intra-queue_ message priority. In other words, priority 
+    is enforced within, but not between, queues (which themselves can be prioritized).
 
 ### Triggers
 

--- a/docs/guided_tour.md
+++ b/docs/guided_tour.md
@@ -262,7 +262,7 @@ def my_task() -> int:
 
 As with timeouts, priority values can be set for each task.
 
-Alsek implements _intra-queue_ task priority. In other words, task priority 
+Alsek implements _intra-queue_ message priority. In other words, priority 
 is enforced within, but not between, queues (which themselves can be prioritized).
 
 Let's take a look at an example.
@@ -270,18 +270,17 @@ Let's take a look at an example.
 ```python
 from alsek import task
 
-@task(..., queue="my_queue", priority=0)
+@task(..., queue="my_queue")
 def task_a() -> str:
     return "A!"
 
-@task(..., queue="my_queue", priority=1)
-def task_b() -> str:
-    return "B!"
+message_1 = task_a.generate(priority=1)
+message_2 = task_a.generate(priority=0)
 ```
 
 In Alsek, `priority` is inverted. That is, lower integers correspond to higher priority.
-Thus, in the example above, instances of `task_a()` will _always_ take priority over 
-instances of `task_b()`.
+Thus, in the example above, `message_2` will take priority over 
+instances of `message_1`.
 
 ### Triggers
 

--- a/docs/guided_tour.md
+++ b/docs/guided_tour.md
@@ -27,9 +27,11 @@ backend = DiskCacheBackend()
 ```
 
 !!! warning
-    ``DiskCache`` persists data to a local (Sqlite) database and does not 
-    implement server-side "if not exist" (`nx`) on `SET` support. For these reasons, 
-    ``DiskCacheBackend()`` is recommended for development and testing purposes only.
+    ``DiskCache`` persists data to a local (Sqlite) database and does
+    not implement 'server-side' "if not exist" on `SET` (`nx`) support or
+    true priority capabilities. For these reasons, ``DiskCacheBackend()`` is
+    recommended for development and testing purposes only. (Multi-worker setups
+    in particular should not be used with this backend.)
 
 ### Lazy Initialization
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
 name = alsek
-version = 0.7.3
+version = 0.8.0
 author = Tariq Hassan

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ def rolling_backend(
     if request.param == "redis":
         return RedisBackend(custom_redisdb)
     elif request.param == "diskcache":
-        return RedisBackend(custom_redisdb)
+        return DiskCacheBackend(tmp_path)
     else:
         raise ValueError(f"Unknown backend '{request.param}'")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,9 @@ def base_backend() -> Backend:
         def priority_get(self, key: str) -> Optional[str]:
             raise NotImplementedError()
 
+        def priority_delete(self, key: str) -> None:
+            raise NotImplementedError()
+
         def pub(self, channel: str, value: Any) -> None:
             raise NotImplementedError()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,10 @@ def base_backend() -> Backend:
         def priority_get(self, key: str) -> Optional[str]:
             raise NotImplementedError()
 
-        def priority_delete(self, key: str) -> None:
+        def priority_iter(self, key: str) -> Iterable[str]:
+            raise NotImplementedError()
+
+        def priority_remove(self, key: str) -> None:
             raise NotImplementedError()
 
         def pub(self, channel: str, value: Any) -> None:
@@ -118,7 +121,7 @@ def rolling_backend(
     if request.param == "redis":
         return RedisBackend(custom_redisdb)
     elif request.param == "diskcache":
-        return DiskCacheBackend(tmp_path)
+        return RedisBackend(custom_redisdb)
     else:
         raise ValueError(f"Unknown backend '{request.param}'")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def base_backend() -> Backend:
         ) -> Any:
             raise NotImplementedError()
 
-        def priority_add(self, key: str, member: str, priority: int | float) -> None:
+        def priority_add(self, key: str, unique_id: str, priority: int | float) -> None:
             raise NotImplementedError()
 
         def priority_get(self, key: str) -> Optional[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,12 @@ def base_backend() -> Backend:
         ) -> Any:
             raise NotImplementedError()
 
+        def priority_add(self, key: str, member: str, priority: int | float) -> None:
+            raise NotImplementedError()
+
+        def priority_get(self, key: str) -> Optional[str]:
+            raise NotImplementedError()
+
         def pub(self, channel: str, value: Any) -> None:
             raise NotImplementedError()
 

--- a/tests/core/test_broker.py
+++ b/tests/core/test_broker.py
@@ -4,7 +4,7 @@
 
 """
 
-from typing import Optional, Union
+from typing import Optional
 
 import pytest
 
@@ -142,7 +142,7 @@ def test_nack(rolling_broker: Broker) -> None:
     # Now nack it
     rolling_broker.nack(message)
 
-    # Check that the broker did not removed the message
+    # Check that the broker did not remove the message
     assert rolling_broker.exists(message)
 
     # Check that the lock has been fully released.

--- a/tests/core/test_broker.py
+++ b/tests/core/test_broker.py
@@ -13,7 +13,7 @@ from alsek.core.broker import Broker
 from alsek.core.concurrency import Lock
 from alsek.core.message import Message
 from alsek.exceptions import MessageDoesNotExistsError
-from alsek.utils.namespacing import get_message_name, get_dlq_message_name
+from alsek.utils.namespacing import get_dlq_message_name, get_message_name
 from tests._helpers import sleeper
 
 

--- a/tests/core/test_consumer.py
+++ b/tests/core/test_consumer.py
@@ -12,6 +12,7 @@ from alsek.core.broker import Broker
 from alsek.core.concurrency import Lock
 from alsek.core.consumer import Consumer, Message, _ConsumptionMutex
 from alsek.storage.backends import Backend
+from alsek.utils.namespacing import get_message_name
 
 
 def test_consumption_mutex_acquisition(rolling_backend: Backend) -> None:
@@ -61,7 +62,7 @@ def test_scan_subnamespaces(
     actual = set(consumer._scan_subnamespaces())
 
     # Validate that the expected messages were recovered
-    expected = {rolling_broker.get_message_name(m) for m in target_messages}
+    expected = {get_message_name(m) for m in target_messages}
     assert actual == expected
 
 

--- a/tests/core/test_consumer.py
+++ b/tests/core/test_consumer.py
@@ -47,6 +47,7 @@ def test_poll_queue_and_task(
     consumer = Consumer(rolling_broker, subset=subset)
 
     # Define messages
+    # Note: these initial messages are decoys when `subset != None`.
     messages = [Message("task") for _ in range(3)]
     if isinstance(subset, list):
         target_messages = [Message("task", queue=q) for q in subset]

--- a/tests/core/test_consumer.py
+++ b/tests/core/test_consumer.py
@@ -40,6 +40,7 @@ def test_consumption_mutex_settings(rolling_backend: Backend) -> None:
         {"queue-a": ["task-a", "task-b"]},
     ],
 )
+@pytest.mark.timeout(10)
 def test_poll_queue_and_task(
     subset: Optional[Union[list[str], dict[str, list[str]]]],
     rolling_broker: Broker,

--- a/tests/core/test_consumer.py
+++ b/tests/core/test_consumer.py
@@ -4,7 +4,7 @@
 
 """
 
-from typing import Optional, Union, Iterable, Any
+from typing import Any, Iterable, Optional, Union
 
 import pytest
 
@@ -115,8 +115,8 @@ def test_stream(messages_to_add: int, rolling_broker: Broker) -> None:
 
 
 if __name__ == "__main__":
-    from alsek.storage.backends.redis import RedisBackend
     from alsek.storage.backends.disk import DiskCacheBackend
+    from alsek.storage.backends.redis import RedisBackend
 
     messages_to_add = 2
     subset = None

--- a/tests/core/test_consumer.py
+++ b/tests/core/test_consumer.py
@@ -110,3 +110,14 @@ def test_stream(messages_to_add: int, rolling_broker: Broker) -> None:
         count += 1
         if count >= len(messages):
             break
+
+
+if __name__ == "__main__":
+    from alsek.storage.backends.redis import RedisBackend
+    from alsek.storage.backends.disk import DiskCacheBackend
+
+    messages_to_add = 2
+    subset = None
+    rolling_broker = Broker(DiskCacheBackend())
+    rolling_broker.backend.clear_namespace()
+    sorted(rolling_broker.backend.scan("queues:*"))

--- a/tests/utils/test_namespacing.py
+++ b/tests/utils/test_namespacing.py
@@ -13,7 +13,8 @@ from alsek.utils.namespacing import (
     get_priority_namespace,
     get_priority_namespace_from_message,
     get_dlq_message_name,
-    get_message_name, get_subnamespace,
+    get_message_name,
+    get_subnamespace,
 )
 
 

--- a/tests/utils/test_namespacing.py
+++ b/tests/utils/test_namespacing.py
@@ -3,11 +3,18 @@
     Test Namespacing
 
 """
+
 import pytest
 from typing import Optional, Union
 
 from alsek import Message
-from alsek.utils.namespacing import get_subnamespace, get_message_name
+from alsek.utils.namespacing import (
+    get_messages_namespace,
+    get_priority_namespace,
+    get_priority_namespace_from_message,
+    get_dlq_message_name,
+    get_message_name, get_subnamespace,
+)
 
 
 @pytest.mark.parametrize(
@@ -57,4 +64,63 @@ def test_get_message_name(
     assert actual == expected
 
 
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        (
+            Message("task-x", queue="queue-x", uuid="uuid-x"),
+            "queues:queue-x:tasks:task-x:messages",
+        ),
+        (
+            Message("task-y", queue="queue-y", uuid="uuid-y"),
+            "queues:queue-y:tasks:task-y:messages",
+        ),
+    ],
+)
+def test_get_messages_namespace(message: Message, expected: str) -> None:
+    assert get_messages_namespace(message) == expected
 
+
+@pytest.mark.parametrize(
+    "subnamespace,expected",
+    [
+        ("queues:q1:tasks:t1", "priority:queues:q1:tasks:t1"),
+        ("queues:q2", "priority:queues:q2"),
+    ],
+)
+def test_get_priority_namespace(subnamespace: str, expected: str) -> None:
+    assert get_priority_namespace(subnamespace) == expected
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        (
+            Message("task-a", queue="queue-a", uuid="uuid-a"),
+            "priority:queues:queue-a:tasks:task-a",
+        ),
+        (
+            Message("task-b", queue="queue-b", uuid="uuid-b"),
+            "priority:queues:queue-b:tasks:task-b",
+        ),
+    ],
+)
+def test_get_priority_namespace_from_message(message: Message, expected: str) -> None:
+    assert get_priority_namespace_from_message(message) == expected
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        (
+            Message("task-a", queue="queue-a", uuid="uuid-a"),
+            "dlq:queues:queue-a:tasks:task-a:messages:uuid-a",
+        ),
+        (
+            Message("task-b", queue="queue-b", uuid="uuid-b"),
+            "dlq:queues:queue-b:tasks:task-b:messages:uuid-b",
+        ),
+    ],
+)
+def test_get_dlq_message_name(message: Message, expected: str) -> None:
+    assert get_dlq_message_name(message) == expected

--- a/tests/utils/test_namespacing.py
+++ b/tests/utils/test_namespacing.py
@@ -1,0 +1,60 @@
+"""
+
+    Test Namespacing
+
+"""
+import pytest
+from typing import Optional, Union
+
+from alsek import Message
+from alsek.utils.namespacing import get_subnamespace, get_message_name
+
+
+@pytest.mark.parametrize(
+    "queue,task_name,expected",
+    [
+        # No Queue & Task
+        (None, "task", ValueError),
+        # Queue & task
+        ("queue", "task", "queues:queue:tasks:task"),
+        # Queue only
+        ("queue", None, "queues:queue"),
+        # No queue & no task
+        (None, None, "queues"),
+    ],
+)
+def test_get_subnamespace(
+    queue: Optional[str],
+    task_name: Optional[str],
+    expected: Union[Exception, str],
+) -> None:
+    if isinstance(expected, str):
+        actual = get_subnamespace(queue, task_name=task_name)
+        assert actual == expected
+    else:
+        with pytest.raises(expected):
+            get_subnamespace(queue, task_name=task_name)
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        (
+            Message("task-a", queue="queue-a", uuid="uuid-a"),
+            "queues:queue-a:tasks:task-a:messages:uuid-a",
+        ),
+        (
+            Message("task-b", queue="queue-b", uuid="uuid-b"),
+            "queues:queue-b:tasks:task-b:messages:uuid-b",
+        ),
+    ],
+)
+def test_get_message_name(
+    message: Message,
+    expected: Union[BaseException, str],
+) -> None:
+    actual = get_message_name(message)
+    assert actual == expected
+
+
+

--- a/tests/utils/test_namespacing.py
+++ b/tests/utils/test_namespacing.py
@@ -4,16 +4,17 @@
 
 """
 
-import pytest
 from typing import Optional, Union
+
+import pytest
 
 from alsek import Message
 from alsek.utils.namespacing import (
+    get_dlq_message_name,
+    get_message_name,
     get_messages_namespace,
     get_priority_namespace,
     get_priority_namespace_from_message,
-    get_dlq_message_name,
-    get_message_name,
     get_subnamespace,
 )
 

--- a/tests/utils/test_namespacing.py
+++ b/tests/utils/test_namespacing.py
@@ -39,7 +39,7 @@ def test_get_subnamespace(
         actual = get_subnamespace(queue, task_name=task_name)
         assert actual == expected
     else:
-        with pytest.raises(expected):
+        with pytest.raises(expected):  # noqa
             get_subnamespace(queue, task_name=task_name)
 
 


### PR DESCRIPTION
## Overview

Add the ability to specify priority at the message level instead of task-level.

## ToDo

- [x] Harmonize priority for queue and message
     * Should respect queue < message priority 
- [x] Unit tests for the new `priority_*()` methods