### PR TITLE
Task Revocation Improvement: Add configurable thread completion behaviour

### DIFF
--- a/alsek/__init__.py
+++ b/alsek/__init__.py
@@ -10,4 +10,4 @@ from alsek.core.message import Message
 from alsek.core.status import StatusTracker
 from alsek.core.task import task
 
-__version__: str = "0.8.3"
+__version__: str = "0.8.4"

--- a/alsek/cli/cli.py
+++ b/alsek/cli/cli.py
@@ -117,6 +117,12 @@ def _configure_reload(package: str) -> Observer:
     "determine if a process for task execution is available.",
 )
 @click.option(
+    "--complete_only_on_thread_exit",
+    is_flag=True,
+    help="Only mark thread futures as complete when the thread exits. "
+         "More rigorous, but may hang if the thread doesn't terminate cleanly.",
+)
+@click.option(
     "--consumer_backoff_factor",
     type=int,
     default=1 * 1000,
@@ -162,6 +168,7 @@ def main(
     max_processes: Optional[int],  # noqa
     management_interval: int,  # noqa
     slot_wait_interval: int,  # noqa
+    complete_only_on_thread_exit: bool,  # noqa
     consumer_backoff_factor: int,  # noqa
     consumer_backoff_floor: int,  # noqa
     consumer_backoff_ceiling: int,  # noqa
@@ -203,6 +210,7 @@ def main(
             max_processes=max_processes,
             management_interval=management_interval,
             slot_wait_interval=slot_wait_interval,
+            complete_only_on_thread_exit=complete_only_on_thread_exit,
             backoff=LinearBackoff(
                 factor=consumer_backoff_factor,
                 floor=consumer_backoff_floor,

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -108,7 +108,7 @@ class WorkerPool(Consumer):
         task_specific_mode: bool = False,
         max_threads: int = 8,
         max_processes: Optional[int] = None,
-        management_interval: int = 100,
+        management_interval: int = 75,
         slot_wait_interval: int = 100,
         **kwargs: Any,
     ) -> None:

--- a/alsek/core/worker.py
+++ b/alsek/core/worker.py
@@ -91,6 +91,14 @@ class WorkerPool(Consumer):
             maintenance scans of background task execution.
         slot_wait_interval (int): amount of time (in milliseconds) to wait
             between checks to determine worker availability for pending tasks.
+        complete_only_on_thread_exit (bool): if ``True``, only mark the future
+            as complete when the thread formally exits (i.e., is not alive).
+            Pro: more rigorous — avoids marking the task complete until the thread fully terminates.
+            Useful when you need strict control over thread lifecycle (e.g., for resource management).
+            Con: may lead to hanging if the thread doesn’t terminate quickly (e.g., when using
+            `thread_raise()` during revocation). Can also temporarily result in more than the
+            allotted number of threads running, since a future is only removed from the pool
+            after the thread is confirmed dead.
         **kwargs (Keyword Args): Keyword arguments to pass to ``Consumer()``.
 
     Raises:
@@ -110,6 +118,7 @@ class WorkerPool(Consumer):
         max_processes: Optional[int] = None,
         management_interval: int = 75,
         slot_wait_interval: int = 100,
+        complete_only_on_thread_exit: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -128,6 +137,7 @@ class WorkerPool(Consumer):
         self.max_processes = max_processes or smart_cpu_count()
         self.management_interval = management_interval
         self.slot_wait_interval = slot_wait_interval
+        self.complete_only_on_thread_exit = complete_only_on_thread_exit
 
         self._task_map = {t.name: t for t in tasks}
         self._futures: dict[str, list[TaskFuture]] = dict(thread=list(), process=list())
@@ -182,7 +192,11 @@ class WorkerPool(Consumer):
     def _make_future(self, message: Message) -> TaskFuture:
         task = self._task_map[message.task_name]
         if message.mechanism == "thread":
-            return ThreadTaskFuture(task, message=message)
+            return ThreadTaskFuture(
+                task=task,
+                message=message,
+                complete_only_on_thread_exit=self.complete_only_on_thread_exit,
+            )
         elif message.mechanism == "process":
             return ProcessTaskFuture(task, message=message)
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
 name = alsek
-version = 0.8.3
+version = 0.8.4
 author = Tariq Hassan


### PR DESCRIPTION
## Overview

### Problem
When a task is revoked in Alsek, the `ThreadTaskFuture.stop()` method uses `thread_raise()` to inject an exception into the running thread. However, this is a "fire-and-forget" mechanism that doesn't guarantee immediate thread termination. The thread may continue running for minutes before reaching a Python interpreter checkpoint where it can process the exception.

During this time, the worker pool keeps track of these "zombie" threads in its `_futures` list because they're not considered `complete` until they actually terminate. This prevents the worker from polling for new tasks, as slots appear to be filled even though the tasks have been revoked.

In our testing, we observed a 2-minute gap between task revocation and thread termination, during which no new tasks were processed:

```
[2025-04-24 14:54:14.796] [Thread-5 (_revocation_scan)] [INFO] alsek.core.futures: Evicted 'Message(uuid='8e8f41f5...)'
[2025-04-24 14:56:09.915] [Thread-6 (_wrapper)] [INFO] alsek.core.futures: Result for Message(uuid='8e8f41f5...') recovered after revocation. Discarding.
```

### Solution

Added a configurable parameter `complete_only_on_thread_exit` that provides two options for determining when a thread future is considered complete:

1. **`complete_only_on_thread_exit=True`**: More rigorous approach that only marks a future as complete when the thread actually terminates. This ensures proper resource cleanup but may block worker slots during long-running revoked tasks.

2. **`complete_only_on_thread_exit=False`** (default): Marks a future as complete either when the thread terminates OR when the task is revoked. This allows the worker to immediately free up slots for new tasks, maintaining throughput during revocation scenarios.

Additionally:
- Reduced the default `management_interval` from 100ms to 75ms for faster future cleanup
- Added extensive documentation explaining the tradeoffs
- Exposed the option in both the API and CLI

This improvement gives users flexibility to choose between strict resource management and higher throughput based on their specific requirements.

## Changes

1. Modified `ThreadTaskFuture.complete` property to conditionally check task completion
2. Added `complete_only_on_thread_exit` parameter to `WorkerPool`
3. Added CLI flag `--complete_only_on_thread_exit` to control this behavior
4. Reduced default `management_interval` for faster cleanup
5. Added detailed documentation explaining the options and tradeoffs

This change ensures worker pools can continue processing tasks efficiently even when some tasks need to be revoked, while still giving users who need strict thread lifecycle management the option to maintain that behavior.
