### PR TITLE
Fix: Handle conserve custom classes

### DIFF
--- a/alsek/__init__.py
+++ b/alsek/__init__.py
@@ -10,4 +10,4 @@ from alsek.core.message import Message
 from alsek.core.status.standard import StatusTracker
 from alsek.core.task import task
 
-__version__: str = "1.3.0"
+__version__: str = "1.3.1"

--- a/alsek/core/concurrency.py
+++ b/alsek/core/concurrency.py
@@ -15,9 +15,13 @@ from typing import Any, Literal, Optional, Type, cast, get_args
 
 import redis_lock
 
+import logging
 from alsek.storage.backends.abstract import Backend
 from alsek.storage.backends.redis import RedisBackend
 from alsek.utils.printing import auto_repr
+
+# Suppresses unneeded 'Failed to acquire Lock(...)' errors
+logging.getLogger(redis_lock.logger_for_acquire.name).setLevel(logging.ERROR)
 
 IF_ALREADY_ACQUIRED_TYPE = Literal["raise_error", "return_true", "return_false"]
 
@@ -67,12 +71,12 @@ class Lock:
     """
 
     def __init__(
-        self,
-        name: str,
-        backend: Backend,
-        ttl: Optional[int] = 60 * 60 * 1000,
-        auto_release: bool = True,
-        owner_id: str = CURRENT_HOST_OWNER_ID,
+            self,
+            name: str,
+            backend: Backend,
+            ttl: Optional[int] = 60 * 60 * 1000,
+            auto_release: bool = True,
+            owner_id: str = CURRENT_HOST_OWNER_ID,
     ) -> None:
         self.name = name
         self.backend = backend
@@ -127,9 +131,9 @@ class Lock:
         return self.holder == self.owner_id
 
     def acquire(
-        self,
-        wait: Optional[int] = None,
-        if_already_acquired: IF_ALREADY_ACQUIRED_TYPE = "raise_error",
+            self,
+            wait: Optional[int] = None,
+            if_already_acquired: IF_ALREADY_ACQUIRED_TYPE = "raise_error",
     ) -> bool:
         """Try to acquire the lock.
 
@@ -188,10 +192,10 @@ class Lock:
         return self
 
     def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc_val: Optional[BaseException],
+            exc_tb: Optional[TracebackType],
     ) -> None:
         """Exit the context. If ``auto_release`` is enabled,
          the lock will be released.

--- a/alsek/core/status/asyncio.py
+++ b/alsek/core/status/asyncio.py
@@ -34,7 +34,7 @@ class AsyncStatusTracker(BaseStatusTracker):
     @staticmethod
     def deserialize(data: dict[str, Any]) -> AsyncStatusTracker:
         backend_data = dill.loads(data["backend"])
-        backend = backend_data["backend"]._from_settings(backend_data["settings"])
+        backend = backend_data["backend"].from_settings(backend_data["settings"])
         return AsyncStatusTracker(
             backend=backend,
             ttl=data["ttl"],

--- a/alsek/core/status/standard.py
+++ b/alsek/core/status/standard.py
@@ -20,11 +20,11 @@ from alsek.exceptions import ValidationError
 class StatusTracker(BaseStatusTracker):
     __doc__ = BaseStatusTracker.__doc__
 
-    @staticmethod
-    def deserialize(data: dict[str, Any]) -> StatusTracker:
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> StatusTracker:
         backend_data = dill.loads(data["backend"])
-        backend = backend_data["backend"]._from_settings(backend_data["settings"])
-        return StatusTracker(
+        backend = backend_data["backend"].from_settings(backend_data["settings"])
+        return cls(
             backend=backend,
             ttl=data["ttl"],
             enable_pubsub=data["enable_pubsub"],

--- a/alsek/core/task.py
+++ b/alsek/core/task.py
@@ -176,40 +176,45 @@ class Task:
         self._deferred: bool = False
 
     def serialize(self) -> dict[str, Any]:
-        settings = gather_init_params(self, ignore=("broker",))
+        settings = gather_init_params(
+            self,
+            ignore=("broker", "status_tracker", "result_store"),
+        )
 
         # Broker
         settings["broker_class"] = self.broker.__class__
-        settings["broker"] = self.broker.serialize()
+        settings["broker_state"] = self.broker.serialize()
 
         # Status Tracker
         if self.status_tracker:
             settings["status_tracker_class"] = self.status_tracker.__class__
-            settings["status_tracker"] = self.status_tracker.serialize()
+            settings["status_tracker_state"] = self.status_tracker.serialize()
 
         # Result Store
         if self.result_store:
             settings["result_store_class"] = self.result_store.__class__
-            settings["result_store"] = self.result_store.serialize()
+            settings["result_store_state"] = self.result_store.serialize()
 
         return dict(task=self.__class__, settings=settings)
 
     @staticmethod
     def deserialize(data: dict[str, Any]) -> Task:
         def unwind_settings(settings: dict[str, Any]) -> dict[str, Any]:
+            settings = settings.copy()
+
             # Broker
             broker_class = settings.pop("broker_class")
-            settings["broker"] = broker_class.deserialize(settings["broker"])
+            settings["broker"] = broker_class.deserialize(settings.pop("broker_state"))
 
             # Status Tracker
-            if status_tracker_settings := settings.get("status_tracker"):
+            if status_tracker_state := settings.pop("status_tracker_state", None):
                 status_tracker_class = settings.pop("status_tracker_class")
-                settings["status_tracker"] = status_tracker_class.deserialize(status_tracker_settings)  # fmt: skip
+                settings["status_tracker"] = status_tracker_class.deserialize(status_tracker_state)  # fmt: skip
 
             # Result Store
-            if result_store_settings := settings.get("result_store"):
+            if result_store_state := settings.pop("result_store_state", None):
                 result_store_class = settings.pop("result_store_class")
-                settings["result_store"] = result_store_class.deserialize(result_store_settings)  # fmt: skip
+                settings["result_store"] = result_store_class.deserialize(result_store_state)  # fmt: skip
 
             return settings
 

--- a/alsek/core/task.py
+++ b/alsek/core/task.py
@@ -180,15 +180,18 @@ class Task:
         settings = gather_init_params(self, ignore=("broker",))
 
         # Broker
+        settings["broker_class"] = self.broker.__class__
         settings["broker"] = gather_init_params(self.broker, ignore=("backend",))
         settings["broker"]["backend"] = self.broker.backend.encode()
 
         # Status Tracker
         if self.status_tracker:
+            settings["status_tracker_class"] = self.status_tracker.__class__
             settings["status_tracker"] = self.status_tracker.serialize()
 
         # Result Store
         if self.result_store:
+            settings["result_store_class"] = self.result_store.__class__
             settings["result_store"] = self.result_store.serialize()
 
         return dict(task=self.__class__, settings=settings)
@@ -196,23 +199,21 @@ class Task:
     @staticmethod
     def deserialize(data: dict[str, Any]) -> Task:
         def unwind_settings(settings: dict[str, Any]) -> dict[str, Any]:
-            backend_data = dill.loads(settings["broker"]["backend"])
-
             # Broker
-            settings["broker"]["backend"] = backend_data["backend"]._from_settings(
-                backend_data["settings"]
-            )
-            settings["broker"] = Broker(**settings["broker"])
+            broker_class = settings.pop("broker_class")
+            backend_data = dill.loads(settings["broker"]["backend"])
+            settings["broker"]["backend"] = backend_data["backend"].from_settings(backend_data["settings"])  # fmt: skip
+            settings["broker"] = broker_class(**settings["broker"])
 
             # Status Tracker
             if status_tracker_settings := settings.get("status_tracker"):
-                settings["status_tracker"] = StatusTracker.deserialize(status_tracker_settings)  # fmt: skip
+                status_tracker_class = settings.pop("status_tracker_class")
+                settings["status_tracker"] = status_tracker_class.deserialize(status_tracker_settings)  # fmt: skip
 
             # Result Store
             if result_store_settings := settings.get("result_store"):
-                settings["result_store"] = ResultStore.deserialize(
-                    result_store_settings
-                )
+                result_store_class = settings.pop("result_store_class")
+                settings["result_store"] = result_store_class.deserialize(result_store_settings)  # fmt: skip
 
             return settings
 

--- a/alsek/storage/backends/abstract.py
+++ b/alsek/storage/backends/abstract.py
@@ -56,7 +56,7 @@ class BaseBackend(ABC):
         return cast(bytes, dill.dumps(data))
 
     @classmethod
-    def _from_settings(cls, settings: dict[str, Any]) -> Backend:
+    def from_settings(cls, settings: dict[str, Any]) -> Backend:
         return cls(**settings)
 
     def in_namespace(self, name: str) -> bool:

--- a/alsek/storage/backends/abstract.py
+++ b/alsek/storage/backends/abstract.py
@@ -56,7 +56,7 @@ class BaseBackend(ABC):
         return cast(bytes, dill.dumps(data))
 
     @classmethod
-    def from_settings(cls, settings: dict[str, Any]) -> Backend:
+    def from_settings(cls, settings: dict[str, Any]) -> BaseBackend:
         return cls(**settings)
 
     def in_namespace(self, name: str) -> bool:

--- a/alsek/storage/backends/abstract.py
+++ b/alsek/storage/backends/abstract.py
@@ -52,6 +52,7 @@ class BaseBackend(ABC):
         )
 
     def encode(self) -> bytes:
+        # ToDo: drop `backend` and just dump settings.
         data = dict(backend=self.__class__, settings=gather_init_params(self))
         return cast(bytes, dill.dumps(data))
 

--- a/alsek/storage/backends/redis/asyncio.py
+++ b/alsek/storage/backends/redis/asyncio.py
@@ -117,7 +117,7 @@ class AsyncRedisBackend(AsyncBackend):
         return dill.dumps(data)
 
     @classmethod
-    def _from_settings(cls, settings: dict[str, Any]) -> AsyncRedisBackend:
+    def from_settings(cls, settings: dict[str, Any]) -> AsyncRedisBackend:
         settings["conn"] = RedisAsync(
             connection_pool=AsyncConnectionPool(
                 connection_class=settings["conn"]["connection_class"],

--- a/alsek/storage/backends/redis/standard.py
+++ b/alsek/storage/backends/redis/standard.py
@@ -100,7 +100,7 @@ class RedisBackend(Backend):
         return cast(bytes, dill.dumps(data))
 
     @classmethod
-    def _from_settings(cls, settings: dict[str, Any]) -> RedisBackend:
+    def from_settings(cls, settings: dict[str, Any]) -> RedisBackend:
         settings["conn"] = Redis(
             connection_pool=ConnectionPool(
                 connection_class=settings["conn"]["connection_class"],

--- a/alsek/storage/result.py
+++ b/alsek/storage/result.py
@@ -38,11 +38,11 @@ class ResultStore:
             "backend": self.backend.encode(),
         }
 
-    @staticmethod
-    def deserialize(data: dict[str, Any]) -> ResultStore:
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> ResultStore:
         backend_data = dill.loads(data["backend"])
-        backend = backend_data["backend"]._from_settings(backend_data["settings"])
-        return ResultStore(
+        backend = backend_data["backend"].from_settings(backend_data["settings"])
+        return cls(
             backend=backend,
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
 name = alsek
-version = 1.3.0
+version = 1.3.1
 author = Tariq Hassan

--- a/tests/core/test_concurrency.py
+++ b/tests/core/test_concurrency.py
@@ -86,7 +86,7 @@ def test_context(auto_release: bool, rolling_backend: Backend) -> None:
 def _rebuild_backend(encoded: bytes) -> Backend:
     data: dict[str, Any] = dill.loads(encoded)
     backend_cls = data["backend"]
-    return backend_cls._from_settings(data["settings"])  # noqa
+    return backend_cls.from_settings(data["settings"])  # noqa
 
 
 def test_owner_id_isolation(rolling_backend: Backend) -> None:

--- a/tests/storage/backends/test_sync_backend.py
+++ b/tests/storage/backends/test_sync_backend.py
@@ -70,7 +70,7 @@ def test_exists(name: str, do_set: bool, rolling_backend: Backend) -> None:
 
 def test_encoding(rolling_backend: Backend) -> None:
     encoded_backend = rolling_backend.encode()
-    decoded_backend = rolling_backend._from_settings(
+    decoded_backend = rolling_backend.from_settings(
         dill.loads(encoded_backend)["settings"]
     )
     # Verify that the reconstruction yielded the same class type


### PR DESCRIPTION
## Overview

  * Conserve any custom `Backend()`, `Broker()`, `StatusTracker()` or `ResultStore()` through `Task.serialize()` and `Task.deserialize()`